### PR TITLE
Update documentation of fix propel/self

### DIFF
--- a/doc/src/Commands_fix.txt
+++ b/doc/src/Commands_fix.txt
@@ -157,6 +157,7 @@ OPT.
 "precession/spin"_fix_precession_spin.html,
 "press/berendsen"_fix_press_berendsen.html,
 "print"_fix_print.html,
+"propel/self"_fix_propel_self.html,
 "property/atom (k)"_fix_property_atom.html,
 "python/invoke"_fix_python_invoke.html,
 "python/move"_fix_python_move.html,

--- a/doc/src/fix.txt
+++ b/doc/src/fix.txt
@@ -296,6 +296,7 @@ accelerated styles exist.
 "precession/spin"_fix_precession_spin.html -
 "press/berendsen"_fix_press_berendsen.html - pressure control by Berendsen barostat
 "print"_fix_print.html - print text and variables during a simulation
+"propel/self"_fix_propel_self.html - add self-propelling force
 "property/atom"_fix_property_atom.html - add customized per-atom values
 "python/invoke"_fix_python_invoke.html - call a Python function during a simulation
 "python/move"_fix_python_move.html -  call a Python function during a simulation run

--- a/doc/src/fix_propel_self.txt
+++ b/doc/src/fix_propel_self.txt
@@ -6,7 +6,7 @@
 
 :line
 
-fix propel/self command  :pre
+fix propel/self command  :h3
 
 [Syntax:]
 
@@ -36,13 +36,16 @@ fix active all propel/self quaternion 1.0 types 1 2 4 :pre
 
 Adds a force of a constant magnitude to each atom in the group. The nature in
 which the force is added depends on the mode.
-For mode = velocity, the active force acts along the velocity vector of each
-atom. This can be interpreted as an overdamped form of the model used by
-"(Szabo)"_#Szabo and "(Henkes)"_#Henkes.
-For mode = quaternion the force is along the axis obtained by rotating the
-z-axis along the atom's quaternion. In other words, the force is along the
-z-axis in the atom's body frame. This mode requires all atoms in the group
-to have a quaternion, so atom_style should either be ellipsoid or body.
+
+For mode = velocity, the active force acts along the velocity vector of each atom. This can
+be interpreted as a velocity-dependent friction, such as proposed by "(Erdmann)"_#Erdmann.
+
+For mode = quaternion the force is along the axis obtained by rotating the z-axis along the
+atom's quaternion. In other words, the force is along the z-axis in the atom's body
+frame. This mode requires all atoms in the group to have a quaternion, so atom_style should
+either be ellipsoid or body.  In combination with Langevin thermostat for translation and
+rotation in the overdamped regime, the quaternion mode corresponds to the active Brownian
+particle model introduced by "(Henkes)"_#Henkes, "(Bialke)"_#Bialke and "(Fily)"_#Fily.
 
 By default, this fix is applied to all atoms in the group. You can override this
 behavior by specifying the atom types the fix should work on through the {types}
@@ -59,22 +62,27 @@ This fix is not imposed  during minimization.
 
 [Restrictions:]
 
-This fix makes use of per-atom quaternions to take into
-account the fact that the orientation can rotate and hence the direction
-of the active force can change. Therefore, this fix only works with atom_styles
-that have a quaternion.
+In quaternion mode, this fix makes use of per-atom quaternions to take into account the fact
+that the orientation can rotate and hence the direction of the active force can
+change. Therefore, the quaternion mode of this fix only works with atom_styles that have a
+quaternion.
 
 [Related commands:]
 
 "fix setforce"_fix_setforce.html, "fix addforce"_fix_addforce.html
 
-:link(Szabo)
-[(Szabo)] Szabo, B, Szollosi, G. J., Gonci, B., Juranyi, Zs., Selmeczi, D. and Viscek, T.,
-Phys. Rev. E, 74, 061908, 2006
+:link(Erdmann)
+[(Erdmann)] U. Erdmanna , W. Ebeling, L. Schimansky-Geier, and F. Schweitzer,
+Eur. Phys. J. B 15, 105-113, 2000.
 
 :link(Henkes)
-[(Henkes)] Henkes, S, Fily, Y., and Marchetti, M. C.
-Phys. Rev. E, 84, 040301(R), 2011
+[(Henkes)] Henkes, S, Fily, Y., and Marchetti, M. C. Phys. Rev. E, 84, 040301(R), 2011
+
+:link(Bialke)
+[(Bialke)] J. Bialké, T. Speck, and H Löwen, Phys. Rev. Lett. 108, 168301, 2012.
+
+:link(Fily)
+[(Fily)] Y. Fily and M.C. Marchetti, Phys. Rev. Lett. 108, 235702, 2012.
 
 
 [Default:] types


### PR DESCRIPTION
1. Remove reference to velocity alignment model.
2. Use reference to velocity-dependent friction for mode velocity
3. Add references to Fily & Marchetti and Bialké, Speck & Löwen for the
quaternion mode.

